### PR TITLE
Add league support for soccer's US Open Cup and the USL Championship

### DIFF
--- a/leagues.json
+++ b/leagues.json
@@ -782,6 +782,37 @@
       }
     ]
   },
+  "usopen": {
+    "name": "U.S. Open Cup",
+    "aliases": [
+      "usa open cup",
+      "usa open",
+      "us open"
+    ],
+    "providers": [
+      {
+        "espn": {
+          "espnSlug": "usa.open",
+          "espnSport": "soccer"
+        }
+      }
+    ]
+  },
+  "usl": {
+    "name": "USL Championship",
+    "aliases": [
+      "usl",
+      "usl championship"
+    ],
+    "providers": [
+      {
+        "espn": {
+          "espnSlug": "usa.usl.1",
+          "espnSport": "soccer"
+        }
+      }
+    ]
+  },
   "championship": {
     "name": "EFL Championship",
     "aliases": [


### PR DESCRIPTION
## Description

This PR adds the US Open Cup and the USL Championship soccer leagues.

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [x] New league/sport support
- [ ] Team data correction/override
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Changes Made

<!-- List the specific changes in this PR -->

- Adds U.S. Open Cup (ESPN / soccer / usa.open)
- Adds USL Championship (ESPN / soccer / usa.usl.1)

## Related Issue

<!-- Link to related issue(s) if applicable -->

N/A

## Testing

<!-- Describe how you tested these changes -->

- [x] Tested locally
- [ ] Added/updated tests
- [x] Verified endpoints work as expected

**Test Details:**
Validated team and match examples (screenshots below)

## Screenshots/Examples

<img width="929" height="718" alt="image" src="https://github.com/user-attachments/assets/3418f3e7-7ecb-409c-a5af-60274a713691" />
<img width="1034" height="814" alt="image" src="https://github.com/user-attachments/assets/768ac695-cbad-4e1e-aee4-47204263e31c" />

<img width="979" height="780" alt="image" src="https://github.com/user-attachments/assets/d81be0eb-6cdd-47f7-af9e-05873a7a1512" />


```
GET /usl/rhodeisland/thumb
GET /uropen/newenglandrevolution/thumb
GET /uropen/newenglandrevolution/rhodeisland/thumb
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have updated documentation if needed
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly

## Additional Notes

<!-- Any other context or information reviewers should know -->
