### PR TITLE
Update ESPN slug for UEFA Europa Conference League

### DIFF
--- a/leagues.json
+++ b/leagues.json
@@ -303,14 +303,16 @@
     "name": "UEFA Europa Conference League",
     "aliases": [
       "conference league",
+      "uecl",
       "uefa.conference",
+      "uefa.europa.conf",
       "uefaconferenceleague",
       "uefaeuropaconfleague"
     ],
     "providers": [
       {
         "espn": {
-          "espnSlug": "uefa.conference",
+          "espnSlug": "uefa.europa.conf",
           "espnSport": "soccer"
         }
       }


### PR DESCRIPTION
Updates to the correct ESPN slug for UEFA Europa Conference League and adds aliases `UECL` and the new slug